### PR TITLE
[Fix]: correct error variants and typos in Car-Auction lottery contract

### DIFF
--- a/Car-Auction-Dapp/Contract/error.rs
+++ b/Car-Auction-Dapp/Contract/error.rs
@@ -4,11 +4,11 @@ use anchor_lang::prelude::error_code;
 pub enum LotteryError {
     #[msg("winner already exists")]
     WinnerAlreadyExists,
-    #[msg("Can't choose a winner when there are not tickets")]
+    #[msg("Can't choose a winner when there are no tickets")]
     NoTickets,
-    #[msg("winner not choosen")]
+    #[msg("winner not chosen")]
     WinnerNotChoosen,
-    #[msg("Inalid Winner")]
+    #[msg("Invalid Winner")]
     InvalidWinner,
     #[msg("Already Claimed")]
     AlreadyClaimed,

--- a/Car-Auction-Dapp/Contract/lib.rs
+++ b/Car-Auction-Dapp/Contract/lib.rs
@@ -66,8 +66,8 @@ mod lottery {
         ticket.lottery_id = lottery_id;
         ticket.authority = buyer.key();
 
-        msg!("tikcet id {}", ticket.id);
-        msg!("tikcet authority {}", ticket.authority);
+        msg!("ticket id {}", ticket.id);
+        msg!("ticket authority {}", ticket.authority);
 
         Ok(())
     }
@@ -81,7 +81,7 @@ mod lottery {
             return err!(LotteryError::WinnerAlreadyExists);
         }
 
-        if (lottery.last_ticket_id == 0) {
+        if lottery.last_ticket_id == 0 {
             return err!(LotteryError::NoTickets);
         }
 
@@ -106,7 +106,7 @@ mod lottery {
         let winner = &_ctx.accounts.authority;
 
         if lottery.claimed {
-            return err!(LotteryError::WinnerAlreadyExists);
+            return err!(LotteryError::AlreadyClaimed);
         }
 
         match lottery.winner_id {
@@ -116,7 +116,7 @@ mod lottery {
                 }
             }
             None => {
-                return err!(LotteryError::WinnerAlreadyExists);
+                return err!(LotteryError::WinnerNotChoosen);
             }
         }
 


### PR DESCRIPTION
## Changes

Fixes two semantic bugs and several typos in the Solana/Anchor lottery contract under `Car-Auction-Dapp/Contract/`.

### `lib.rs`

**Bug fix – wrong error variant in `claim_prize` when prize already claimed:**
`lottery.claimed == true` was returning `WinnerAlreadyExists`, which is misleading. Changed to `AlreadyClaimed`, which is the correct variant defined in `error.rs`.

**Bug fix – wrong error variant in `claim_prize` when no winner picked yet:**
The `None` arm of the `winner_id` match was returning `WinnerAlreadyExists` (the opposite of the real problem). Changed to `WinnerNotChoosen` so callers get an actionable error.

**Typo fix in `buy_ticket` msg! macros:**
- `"tikcet id {}"` → `"ticket id {}"`
- `"tikcet authority {}"` → `"ticket authority {}"`

**Style fix in `pick_winner`:**
Removed unnecessary parentheses around the boolean condition `if (lottery.last_ticket_id == 0)` → `if lottery.last_ticket_id == 0` (Rust compiler warns on redundant parens).

### `error.rs`

**Typo fixes in error message strings:**
- `"Can't choose a winner when there are not tickets"` → `"no tickets"`
- `"winner not choosen"` → `"winner not chosen"`
- `"Inalid Winner"` → `"Invalid Winner"`

These are all purely correctness fixes with no behaviour change beyond returning the right error code to callers.