### PR TITLE
[Fix]: stale lotteryId in ticket filter and for...in anti-pattern in context.js

### DIFF
--- a/Car-Auction-Dapp/context/context.js
+++ b/Car-Auction-Dapp/context/context.js
@@ -61,8 +61,11 @@ export const AppProvider = ({ children }) => {
         masterAddress ?? (await getMasterAddress())
       );
       setIntialized(true)
-      setLotteryId(master.lastId);
-      const lotteryAddress = await getLotteryAddress(master.lastId);
+      // Use master.lastId directly — setLotteryId is asynchronous so the
+      // lotteryId state variable is still stale at this point in the function.
+      const currentLotteryId = master.lastId;
+      setLotteryId(currentLotteryId);
+      const lotteryAddress = await getLotteryAddress(currentLotteryId);
       setLotteryAddress(lotteryAddress);
       const lottery = await program.account.lottery.fetch(lotteryAddress);
       setLottery(lottery);
@@ -72,7 +75,7 @@ export const AppProvider = ({ children }) => {
       const userTickets = await program.account.ticket.all([
         {
           memcmp: {
-            bytes: bs58.encode(new BN(lotteryId).toArrayLike(Buffer, "le", 4)),
+            bytes: bs58.encode(new BN(currentLotteryId).toArrayLike(Buffer, "le", 4)),
             offset: 12,
           },
         },
@@ -108,8 +111,10 @@ export const AppProvider = ({ children }) => {
 
     const history = [];
 
-    for (const i in new Array(lotteryId).fill(null)) {
-      const id = lotteryId - parseInt(i);
+    // Use a standard for loop — for...in on an array yields string indices
+    // ("0", "1", ...) which requires parseInt and is an anti-pattern.
+    for (let i = 0; i < lotteryId; i++) {
+      const id = lotteryId - i;
       if (!id) break;
 
       const lotteryAddress = await getLotteryAddress(id);
@@ -182,7 +187,6 @@ export const AppProvider = ({ children }) => {
   const buyTicket = async () => {
     setError("");
     setSuccess("");
-
 
     try {
       console.log("BUYING")


### PR DESCRIPTION
## Summary

Two bugs in `Car-Auction-Dapp/context/context.js` that affect ticket ownership detection and history traversal.

---

### Bug 1 — Stale `lotteryId` state used in ticket filter (`updateState`)

```js
// Before
setLotteryId(master.lastId);          // schedules a state update
// ... later in the same function ...
new BN(lotteryId)                      // reads OLD stale value from closure
```

React state updates are asynchronous — `setLotteryId` schedules a re-render but does not mutate `lotteryId` in the current execution frame. The `memcmp` filter that checks ticket ownership therefore encoded the *previous* lottery ID into the on-chain query, meaning a user who bought tickets in the current lottery would never see their winning status updated correctly.

**Fix:** capture the fresh value in a local variable `currentLotteryId = master.lastId` and use it everywhere in `updateState`.

---

### Bug 2 — `for...in` on an array in `getHistory`

```js
// Before
for (const i in new Array(lotteryId).fill(null)) {
  const id = lotteryId - parseInt(i);   // i is a string — parseInt required
```

`for...in` is designed for object property enumeration, not array iteration. On arrays it yields *string* indices (`"0"`, `"1"`, …), can include inherited enumerable properties, and is flagged by every major linter. The `parseInt` call was a workaround for the string coercion.

**Fix:** replaced with a standard `for (let i = 0; i < lotteryId; i++)` loop — no `parseInt` needed, intent is immediately clear.