### PR TITLE
[Fix]: replace hardcoded RPC API key with env var and fix Table row key

### DIFF
--- a/Car-Auction-Dapp/components/Table.js
+++ b/Car-Auction-Dapp/components/Table.js
@@ -6,11 +6,6 @@ import { PublicKey } from '@solana/web3.js';
 const Table = () => {
 
   const {lotteryHistory} = useAppContext();
-  // const lotteryHistory = [
-  //   { lotteryId: 0, winnerId: 2, winnerAddress: new PublicKey("11111111111111111111111111111111"), prize: '15' },
-  //   { lotteryId: 1, winnerId: 5, winnerAddress: new PublicKey("11111111111111111111111111111111"), prize: '40' },
-  //   { lotteryId: 2, winnerId: 99, winnerAddress: new PublicKey("11111111111111111111111111111111"), prize: '99' },
-  // ]
   return (
     <div className={style.wrapper}>
       <div className={style.tableHeader}>
@@ -20,8 +15,11 @@ const Table = () => {
         <div className={style.amountTitle}>💲 Amount</div>
       </div>
       <div className={style.rows}>
-        {lotteryHistory?.map((h, i) => (
-          <TableRow key={i} {...h} />
+        {lotteryHistory?.map((h) => (
+          // Use the stable lotteryId as the key so React can reconcile rows
+          // correctly across re-renders. Using the array index would cause
+          // incorrect diffing whenever history entries are prepended or removed.
+          <TableRow key={h.lotteryId} {...h} />
         ))}
       </div>
     </div>

--- a/Car-Auction-Dapp/pages/index.js
+++ b/Car-Auction-Dapp/pages/index.js
@@ -13,8 +13,12 @@ import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 require("@solana/wallet-adapter-react-ui/styles.css");
 
 export default function Home() {
+  // Read the RPC endpoint from an environment variable so the QuikNode API
+  // key is not committed to source control.  Set NEXT_PUBLIC_RPC_ENDPOINT in
+  // your .env.local file (never commit that file).
   const endpoint =
-    "https://tiniest-damp-frost.solana-devnet.quiknode.pro/cbe8504b7a4486e60330aeaa06cc64315ddf324f/";
+    process.env.NEXT_PUBLIC_RPC_ENDPOINT ||
+    "https://api.devnet.solana.com";
 
   const wallets = useMemo(() => [new PhantomWalletAdapter()], []);
   return (


### PR DESCRIPTION
## Summary

Two bugs in `Car-Auction-Dapp`.

---

### Bug 1 — Hardcoded QuikNode RPC endpoint in `pages/index.js`

```js
// Before
const endpoint = "https://tiniest-damp-frost.solana-devnet.quiknode.pro/cbe8504b7a4486e60330aeaa06cc64315ddf324f/";

// After
const endpoint =
  process.env.NEXT_PUBLIC_RPC_ENDPOINT ||
  "https://api.devnet.solana.com";
```

The QuikNode URL embeds a private API key in the path. Committing it to source control exposes it to anyone who can read the repository, risks exhausting the quota, and makes key rotation impossible without a new commit.

**Fix:** read from `NEXT_PUBLIC_RPC_ENDPOINT` (Next.js public env var), falling back to the free Solana devnet endpoint. Developers set their own key in `.env.local` which is already git-ignored.

---

### Bug 2 — Array index used as `TableRow` key in `components/Table.js`

```jsx
// Before
{lotteryHistory?.map((h, i) => (
  <TableRow key={i} {...h} />
))}

// After
{lotteryHistory?.map((h) => (
  <TableRow key={h.lotteryId} {...h} />
))}
```

Using the array index as a React key causes incorrect reconciliation when entries are prepended or removed — React maps the wrong component instance to each row. `lotteryId` is already present on every history entry and is a stable, unique identifier.