### PR TITLE
[Fix]: replace deprecated findProgramAddress with findProgramAddressSync in program.js

### DIFF
--- a/Car-Auction-Dapp/utils/program.js
+++ b/Car-Auction-Dapp/utils/program.js
@@ -18,31 +18,31 @@ export const getProgram = (connection, wallet) => {
   return program;
 };
 
-export const getMasterAddress = async () => {
-  return (
-    await PublicKey.findProgramAddress([Buffer.from(MASTER_SEED)], PROGRAM_ID)
+// PublicKey.findProgramAddress is deprecated in favour of the synchronous
+// findProgramAddressSync which avoids unnecessary Promise overhead and is the
+// recommended API in @solana/web3.js >= 1.68.
+export const getMasterAddress = () => {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from(MASTER_SEED)],
+    PROGRAM_ID
   )[0];
 };
 
-export const getLotteryAddress = async (id) => {
-  return (
-    await PublicKey.findProgramAddress(
-      [Buffer.from(LOTTERY_SEED), new BN(id).toArrayLike(Buffer, "le", 4)],
-      PROGRAM_ID
-    )
+export const getLotteryAddress = (id) => {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from(LOTTERY_SEED), new BN(id).toArrayLike(Buffer, "le", 4)],
+    PROGRAM_ID
   )[0];
 };
 
-export const getTicketAddress = async (lotteryPk, id) => {
-  return (
-    await PublicKey.findProgramAddress(
-      [
-        Buffer.from(TICKET_SEED),
-        lotteryPk.toBuffer(),
-        new BN(id).toArrayLike(Buffer, "le", 4),
-      ],
-      PROGRAM_ID
-    )
+export const getTicketAddress = (lotteryPk, id) => {
+  return PublicKey.findProgramAddressSync(
+    [
+      Buffer.from(TICKET_SEED),
+      lotteryPk.toBuffer(),
+      new BN(id).toArrayLike(Buffer, "le", 4),
+    ],
+    PROGRAM_ID
   )[0];
 };
 


### PR DESCRIPTION
## Summary

`Car-Auction-Dapp/utils/program.js` uses `PublicKey.findProgramAddress` which was deprecated in `@solana/web3.js` v1.68 in favour of the synchronous `findProgramAddressSync`.

### Changes

```js
// Before — deprecated async API
export const getMasterAddress = async () => {
  return (
    await PublicKey.findProgramAddress([Buffer.from(MASTER_SEED)], PROGRAM_ID)
  )[0];
};

// After — current synchronous API
export const getMasterAddress = () => {
  return PublicKey.findProgramAddressSync(
    [Buffer.from(MASTER_SEED)],
    PROGRAM_ID
  )[0];
};
```

Applied to all three address helpers: `getMasterAddress`, `getLotteryAddress`, and `getTicketAddress`.

### Why

- `findProgramAddress` is marked deprecated and will be removed in a future major version
- `findProgramAddressSync` is purely CPU-bound (hash computation) — wrapping it in a Promise adds overhead with no benefit
- Removing `async`/`await` from these helpers simplifies call sites and eliminates unnecessary microtask scheduling